### PR TITLE
utils/plot: refactor plotting entry and unify base class

### DIFF
--- a/src/hbtools/utils/common_params/figbase.py
+++ b/src/hbtools/utils/common_params/figbase.py
@@ -1,10 +1,18 @@
 import typer
+from pathlib import Path
 from typing import Annotated
 from dataclasses import dataclass
 
 
 @dataclass
 class FigSetBase:
+    matplotlibrc: Annotated[
+        Path,
+        typer.Option(
+            envvar="MXMF_MATPLOTLIBRC_FILE",
+            help="matplotlibrc style file",
+        ),
+    ] = Path("~/.config/hbtools/matplotlibrc")
     xrange: Annotated[
         tuple[float, float] | None,
         typer.Option(

--- a/src/hbtools/utils/plot_utils.py
+++ b/src/hbtools/utils/plot_utils.py
@@ -197,9 +197,34 @@ class HeatSet:
         cbar.ax.set_ylim(self.vmin, self.vmax)
 
 
-def save_show(params: "common_params.FigSetBase"):
+class FigPlotBase:
+    def __init__(
+        self, params: "common_params.FigSetBase", fig: "figure.Figure", ax: "plt.Axes"
+    ): ...
+
+
+def render_plot(
+    plot_cls: type[FigPlotBase],
+    params: "common_params.FigSetBase",
+):
+    from importlib import resources
+
+    import matplotlib as mpl
     import matplotlib.pyplot as plt
 
+    if params.matplotlibrc.exists():
+        mpl.rc_file(params.matplotlibrc)
+    else:
+        with resources.path("hbtools", "matplotlibrc") as rc_path:
+            if rc_path.exists():
+                mpl.rc_file(rc_path)
+
+    if params.from_cli is False:
+        return (plot_cls, params)
+
+    fig, ax = plt.subplots()
+
+    plot_cls(params, fig, ax)
     for savefile in params.save.split():
         plt.savefig(savefile)
     if params.show:

--- a/src/hbtools/vasp/band/bandplot.py
+++ b/src/hbtools/vasp/band/bandplot.py
@@ -21,13 +21,14 @@ if TYPE_CHECKING:
 
 
 @final
-class BandPlot:
+class BandPlot(plot_utils.FigPlotBase):
     def __init__(
         self,
         params: "BandParams",
         fig: figure.Figure,
         ax: plt.Axes,
     ):
+        super().__init__(params, fig, ax)
         self.params: "BandParams" = params
         self.fig, self.ax = fig, ax
 

--- a/src/hbtools/vasp/cli.py
+++ b/src/hbtools/vasp/cli.py
@@ -16,25 +16,10 @@ app = typer.Typer(no_args_is_help=True)
 @app.command("band")
 @dataclass_cli
 def band(params: BandParams):
-    print(params)
     from ..utils import plot_utils
     from .band.bandplot import BandPlot
 
-    if params.from_cli is False:
-        return (BandPlot, params)
-
-    import matplotlib
-
-    matplotlib.use("qtagg")
-    import matplotlib.pyplot as plt
-    from matplotlib.axes import Axes
-    from matplotlib.figure import Figure
-
-    fig: Figure
-    ax: Axes
-    fig, ax = plt.subplots()
-    _ = BandPlot(params, fig, ax)
-    plot_utils.save_show(params)
+    return plot_utils.render_plot(BandPlot, params)
 
 
 @app.command("dos")
@@ -42,20 +27,10 @@ def band(params: BandParams):
 def dos(
     params: DosParams,
 ):
-    import matplotlib
-
     from ..utils import plot_utils
     from .dos.dosplot import DosPlot
 
-    matplotlib.use("qtagg")
-    if params.from_cli is False:
-        return (DosPlot, params)
-
-    import matplotlib.pyplot as plt
-
-    fig, ax = plt.subplots()
-    DosPlot(params, fig, ax)
-    plot_utils.save_show(params)
+    return plot_utils.render_plot(DosPlot, params)
 
 
 @app.command("nbands_ewin")

--- a/src/hbtools/vasp/dos/dosplot.py
+++ b/src/hbtools/vasp/dos/dosplot.py
@@ -7,6 +7,7 @@ import numpy as np
 from matplotlib import figure
 from matplotlib.patches import Polygon
 
+from hbtools.utils import plot_utils
 from hbtools.utils.plot_utils import AxesSet
 from .. import vasp_utils
 from ..dataread import Readvaspout, ReadVasprun
@@ -79,13 +80,14 @@ def gradient_fill(x, y, ax=None, fill_color=None, **kwargs):
     return line, im
 
 
-class DosPlot:
+class DosPlot(plot_utils.FigPlotBase):
     def __init__(
         self,
         params: "DosParams",
         fig: figure.Figure,
         ax: plt.Axes,
     ):
+        super().__init__(params, fig, ax)
         self.params, self.fig, self.ax = params, fig, ax
         self.fig_set()
         self.plot_tdos()


### PR DESCRIPTION
- add `matplotlibrc` option to `FigSetBase`, configurable via envvar
- introduce `FigPlotBase` to standardize plot class constructor
- refactor `save_show` -> `render_plot`:
  * load matplotlibrc from user or package default
  * create fig/ax and instantiate plot class
  * handle saving and showing automatically
- update `BandPlot` and `DosPlot` to inherit from `FigPlotBase`